### PR TITLE
rgw_sal_motr: fix MotrBucket::list() for prefix

### DIFF
--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -2106,7 +2106,7 @@ int MotrStore::next_query_by_name(string idx_name,
                                   vector<string>& key_str_vec,
                                   vector<bufferlist>& val_bl_vec)
 {
-  int nr_kvp = min_check(val_bl_vec.size(), 100);
+  unsigned nr_kvp = std::min(val_bl_vec.size(), 100UL);
   struct m0_idx idx;
   vector<vector<uint8_t>> key_vec(nr_kvp);
   vector<vector<uint8_t>> val_vec(nr_kvp);
@@ -2124,7 +2124,7 @@ int MotrStore::next_query_by_name(string idx_name,
   // The key_vec will be set will the returned keys from motr index.
   ldout(cctx, 0) << "DEBUG: next_query_by_name(): index=" << idx_name << dendl;
   key_vec[0].assign(prefix.begin(), prefix.end());
-  for (int i = 0; i < val_bl_vec.size(); i += nr_kvp) {
+  for (unsigned long i = 0; i < val_bl_vec.size(); i += nr_kvp) {
     rc = do_idx_next_op(&idx, key_vec, val_vec);
     ldout(cctx, 0) << "do_idx_next_op() = " << rc << dendl;
     if (rc < 0) {
@@ -2132,7 +2132,7 @@ int MotrStore::next_query_by_name(string idx_name,
       goto out;
     }
 
-    for (int j = 0; j < nr_kvp; ++j) {
+    for (unsigned j = 0; j < nr_kvp; ++j) {
       key_str_vec[i + j].assign(key_vec[j].begin(), key_vec[j].end());
       if (prefix.compare(key_str_vec[i + j]) < 0)
 	goto out;

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -534,11 +534,12 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
 
   ldpp_dout(dpp, 0) << "bucket=" << info.bucket.name
                     << " prefix=" << params.prefix
+                    << " marker=" << params.marker
                     << " max=" << max << dendl;
 
   // Retrieve all `max` number of pairs.
   string bucket_index_iname = "motr.rgw.bucket.index." + info.bucket.name;
-  rc = store->next_query_by_name(bucket_index_iname, params.prefix,
+  rc = store->next_query_by_name(bucket_index_iname, params.marker.to_str(),
                                  key_vec, val_vec);
   if (rc < 0) {
     ldpp_dout(dpp, 0) << "ERROR: NEXT query failed. " << rc << dendl;
@@ -561,7 +562,7 @@ int MotrBucket::list(const DoutPrefixProvider *dpp, ListParams& params, int max,
     ocount++;
     if (ocount == max) {
         is_truncated = true;
-        results.next_marker = key_vec[max - 1] + "\x00";
+        results.next_marker = key_vec[max - 1] + " ";
         break;
     }
   }

--- a/src/rgw/rgw_sal_motr.h
+++ b/src/rgw/rgw_sal_motr.h
@@ -1,5 +1,5 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 smarttab ft=cpp
+// vim: ts=2 sw=2 expandtab ft=cpp
 
 /*
  * Ceph - scalable distributed file system
@@ -762,7 +762,7 @@ class MotrStore : public Store {
     int do_idx_next_op(struct m0_idx *idx,
                        vector<vector<uint8_t>>& key_vec,
                        vector<vector<uint8_t>>& val_vec);
-    int next_query_by_name(string idx_name,
+    int next_query_by_name(string idx_name, string prefix,
                            vector<string>& key_str_vec, std::vector<bufferlist>& val_bl_vec);
 
     void index_name_to_motr_fid(string iname, struct m0_uint128 *fid);


### PR DESCRIPTION
Currently, bucket listing does not take key prefix into
account. So it takes all the keys from the bucket and
filters the output after fetching all the keys. This is
a slow and wasteful approach.

Solution: take prefix into account when fetching the
keys from the bucket (motr index) and stop fetching as
soon as the prefix does not match the keys anymore.

Relates to #10.