### PR TITLE
[WIP] Add Motr to rgw-admin

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3261,6 +3261,14 @@ options:
   default: 0x7200000000000001:0x0
   services:
   - rgw
+- name: my_other_motr_fid
+  type: str
+  level: advanced
+  desc: experimental Option to set my Motr fid
+  long_desc: example value 0x7200000000000001:0x29
+  default: 0x7200000000000001:0x0
+  services:
+  - rgw
 - name: my_motr_endpoint
   type: str
   level: advanced

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3988,10 +3988,29 @@ int main(int argc, const char **argv)
     bool need_cache = readonly_ops_list.find(opt_cmd) == readonly_ops_list.end();
     bool need_gc = (gc_ops_list.find(opt_cmd) != gc_ops_list.end()) && !bypass_gc;
 
+    // TODO DRY
+    std::string rgw_store = "rados";
+
+    const auto& config_store = g_conf().get_val<std::string>("rgw_backend_store");
+  #ifdef WITH_RADOSGW_DBSTORE
+    if (config_store == "dbstore") {
+      rgw_store = "dbstore";
+    }
+  #endif
+
+  #ifdef WITH_RADOSGW_MOTR
+    if (config_store == "motr") {
+      rgw_store = "motr";
+    }
+  #endif
+  lsubdout(cct, rgw, 1) << "RGW CONF BACKEND STORE = " << config_store << dendl;
+  lsubdout(cct, rgw, 1) << "RGW BACKEND STORE = " << rgw_store << dendl;
+
+
     if (raw_storage_op) {
-      store = StoreManager::get_raw_storage(dpp(), g_ceph_context, "rados");
+      store = StoreManager::get_raw_storage(dpp(), g_ceph_context, rgw_store);
     } else {
-      store = StoreManager::get_storage(dpp(), g_ceph_context, "rados", false, false, false,
+      store = StoreManager::get_storage(dpp(), g_ceph_context, rgw_store, false, false, false,
 					   false, false,
 					   need_cache && g_conf()->rgw_cache_enabled, need_gc);
     }

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3194,13 +3194,22 @@ void *newMotrStore(CephContext *cct)
     const auto& proc_ep  = g_conf().get_val<std::string>("my_motr_endpoint");
     const auto& ha_ep    = g_conf().get_val<std::string>("motr_ha_endpoint");
     const auto& proc_fid = g_conf().get_val<std::string>("my_motr_fid");
+    const auto& other_proc_fid = g_conf().get_val<std::string>("my_other_motr_fid");
     const auto& profile  = g_conf().get_val<std::string>("motr_profile_fid");
+    const int init_flags = cct->get_init_flags();
+    ldout(cct, 0) << "INFO: init flags:        " << init_flags << dendl;
     ldout(cct, 0) << "INFO: my motr endpoint:  " << proc_ep << dendl;
     ldout(cct, 0) << "INFO: ha agent endpoint: " << ha_ep << dendl;
     ldout(cct, 0) << "INFO: my motr fid:       " << proc_fid << dendl;
+    ldout(cct, 0) << "INFO: my other motr fid: " << other_proc_fid << dendl;
     ldout(cct, 0) << "INFO: motr profile fid:  " << profile << dendl;
     store->conf.mc_local_addr  = proc_ep.c_str();
-    store->conf.mc_process_fid = proc_fid.c_str();
+    // HACK this is so that radosge-admin uses a different client
+    if (init_flags == 0) {
+      store->conf.mc_process_fid = other_proc_fid.c_str();
+    } else {
+      store->conf.mc_process_fid = proc_fid.c_str();
+    }
     store->conf.mc_ha_addr     = ha_ep.c_str();
     store->conf.mc_profile     = profile.c_str();
     store->conf.mc_tm_recv_queue_min_len =     64;


### PR DESCRIPTION
Attempting to change the script `radosgw-admin` to make the store configurable.
To test this, run: 

```shell
cd /your/ceph-build
bin/radosgw-admin user info --uid=tester
```
It should return some information about the default user.