### PR TITLE
rgw_sal_motr: disable motr tracing by default

### DIFF
--- a/src/common/options/rgw.yaml.in
+++ b/src/common/options/rgw.yaml.in
@@ -3277,6 +3277,13 @@ options:
   default: 192.168.180.182@tcp:12345:1:1
   services:
   - rgw
+- name: motr_tracing_enabled
+  type: bool
+  level: advanced
+  desc: Set to true when Motr client debugging is needed
+  default: false
+  services:
+  - rgw
 - name: rgw_luarocks_location
   type: str
   level: advanced

--- a/src/rgw/rgw_sal_motr.cc
+++ b/src/rgw/rgw_sal_motr.cc
@@ -3338,6 +3338,11 @@ void *newMotrStore(CephContext *cct)
       goto out;
     }
 
+    if (!g_conf().get_val<bool>("motr_tracing_enabled")) {
+      m0_trace_level_allow(M0_WARN); // allow errors and warnings in syslog anyway
+      m0_trace_set_mmapped_buffer(false);
+    }
+
   }
 
 out:


### PR DESCRIPTION
Use `motr_tracing_enabled` parameter at ceph.conf to enable it.

Note: motr tracing uses atomic variable to allocate the trace records in the buffer, which impacts the scalability of multithreaded applications, like rgw.

Note2: this change requires updated version of Motr. See https://github.com/Seagate/cortx-motr/pull/1319. The change has already been [landed](https://github.com/Seagate/cortx-motr/commit/ad510936706f94e7e391ee449c8611f2f5ad6d8d) to sage-2.1 Motr branch.